### PR TITLE
TST: Fixed intermod_holder_dll symbols visibility

### DIFF
--- a/test/intermod_holder_dll.hpp
+++ b/test/intermod_holder_dll.hpp
@@ -23,14 +23,10 @@
 #include <boost/flyweight/simple_locking.hpp>
 #include <string>
 
-#ifdef BOOST_HAS_DECLSPEC
 #ifdef BOOST_FLYWEIGHT_TEST_INTERMOD_HOLDER_DLL_SOURCE
-#define BOOST_FLYWEIGHT_DLL_DECL __declspec(dllexport)
+#  define BOOST_FLYWEIGHT_DLL_DECL BOOST_SYMBOL_EXPORT
 #else
-#define BOOST_FLYWEIGHT_DLL_DECL __declspec(dllimport)
-#endif
-#else
-#define BOOST_FLYWEIGHT_DLL_DECL
+#  define BOOST_FLYWEIGHT_DLL_DECL BOOST_SYMBOL_IMPORT
 #endif
 
 typedef boost::flyweights::flyweight<


### PR DESCRIPTION
Currently test_intermod_holder fails to link across nix systems (look at [boost regression matrix](https://www.boost.org/development/tests/develop/developer/flyweight.html) for flyweight) because of recent switch to `-fvisibility=hidden`.