### PR TITLE
Fix copyright headers encoding to UTF-8.

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -1,4 +1,4 @@
-/* Copyright 2003-2004 Joaquín M López Muñoz.
+/* Copyright 2003-2004 JoaquÃ­n M LÃ³pez MuÃ±oz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -1,6 +1,6 @@
 # Boost.Flyweight examples Jamfile
 #
-# Copyright 2006-2014 Joaquín M López Muñoz.
+# Copyright 2006-2014 JoaquÃ­n M LÃ³pez MuÃ±oz.
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,6 +1,6 @@
 # Boost.Flyweight tests Jamfile
 #
-# Copyright 2006-2014 Joaquín M López Muñoz.
+# Copyright 2006-2014 JoaquÃ­n M LÃ³pez MuÃ±oz.
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
I guess UTF-8 is the standard encoding for Boost source files.