### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/include/boost/flyweight/flyweight.hpp
+++ b/include/boost/flyweight/flyweight.hpp
@@ -18,7 +18,7 @@
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <algorithm>
 #include <boost/core/addressof.hpp>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/flyweight/detail/default_value_policy.hpp>
 #include <boost/flyweight/detail/flyweight_core.hpp>
@@ -255,7 +255,7 @@ public:
 
   /* modifiers */
 
-  void swap(flyweight& x){boost::swap(h,x.h);}
+  void swap(flyweight& x){boost::core::invoke_swap(h,x.h);}
   
 private:
   handle_type h;

--- a/include/boost/flyweight/refcounted.hpp
+++ b/include/boost/flyweight/refcounted.hpp
@@ -15,7 +15,7 @@
 
 #include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
 #include <algorithm>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/detail/atomic_count.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/flyweight/refcounted_fwd.hpp>
@@ -138,7 +138,7 @@ public:
 
   void swap(refcounted_handle& x)
   {
-    std::swap(h,x.h);
+    boost::core::invoke_swap(h,x.h);
   }
 
 private:
@@ -161,7 +161,7 @@ void swap(
 } /* namespace flyweights::detail */
 
 #if BOOST_WORKAROUND(BOOST_MSVC,<=1500)
-/* swap lookup by boost::swap fails under obscure circumstances */
+/* swap lookup by boost::core::invoke_swap fails under obscure circumstances */
 
 } /* namespace flyweights */
 


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.