### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/flyweight
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,32 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/flyweight
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/interprocess//boost_interprocess
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_index//boost_multi_index
+        <source>/boost/parameter//boost_parameter
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_flyweight ]
+    [ alias all : boost_flyweight example test ]
+    ;
+
+call-if : boost-library flyweight
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/flyweight

--- a/build.jam
+++ b/build.jam
@@ -5,28 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/container_hash//boost_container_hash
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/interprocess//boost_interprocess
+    /boost/mpl//boost_mpl
+    /boost/multi_index//boost_multi_index
+    /boost/parameter//boost_parameter
+    /boost/preprocessor//boost_preprocessor
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/flyweight
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/container_hash//boost_container_hash
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/interprocess//boost_interprocess
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_index//boost_multi_index
-        <library>/boost/parameter//boost_parameter
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_flyweight ]
+    [ alias boost_flyweight : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_flyweight example test ]
     ;
 
 call-if : boost-library flyweight
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,19 +7,19 @@ import project ;
 
 project /boost/flyweight
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/interprocess//boost_interprocess
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_index//boost_multi_index
-        <source>/boost/parameter//boost_parameter
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/interprocess//boost_interprocess
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_index//boost_multi_index
+        <library>/boost/parameter//boost_parameter
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -9,47 +9,45 @@
 
 project
     : requirements
-      <os>LINUX:<threading>multi
+      <target-os>linux:<threading>multi
     ;
 
 exe basic
     : basic.cpp
-    : <include>$(BOOST_ROOT)
     ;
 
 exe composite
     : composite.cpp
-    : <include>$(BOOST_ROOT)
+      /boost/tokenizer//boost_tokenizer
+      /boost/variant//boost_variant
     ;
 
 exe custom_factory
     : custom_factory.cpp
-    : <include>$(BOOST_ROOT)
+      /boost/tokenizer//boost_tokenizer
     ;
 
 exe fibonacci
     : fibonacci.cpp
-    : <include>$(BOOST_ROOT)
     ;
 
 exe html
     : html.cpp
-    : <include>$(BOOST_ROOT)
     ;
 
 exe key_value
     : key_value.cpp
-    : <include>$(BOOST_ROOT)
+      /boost/array//boost_array
     ;
 
 exe perf
     : perf.cpp
-    : <include>$(BOOST_ROOT)
-    : release
+      /boost/tokenizer//boost_tokenizer
+    :
+    : <variant>release
     ;
 
 exe serialization
     : serialization.cpp
       /boost/serialization//boost_serialization/<link>static
-    : <include>$(BOOST_ROOT)
     ;

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -9,6 +9,7 @@
 
 project
     : requirements
+      <library>/boost/flyweight//boost_flyweight
       <target-os>linux:<threading>multi
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,6 +9,7 @@
 
 project
     : requirements
+      <library>/boost/flyweight//boost_flyweight
       <target-os>linux:<threading>multi
     ;
 
@@ -18,7 +19,7 @@ test-suite "flyweight" :
     [ run test_custom_factory.cpp     test_custom_factory_main.cpp  ]
     [ run test_init.cpp               test_init_main.cpp            ]
     [ run test_intermod_holder.cpp    test_intermod_holder_main.cpp
-          intermod_holder_dll                                       
+          intermod_holder_dll
         : # command line
         : # input files
         : # requirements
@@ -31,6 +32,6 @@ test-suite "flyweight" :
     [ run test_set_factory.cpp        test_set_factory_main.cpp     ]
     ;
 
-lib intermod_holder_dll : intermod_holder_dll.cpp : 
+lib intermod_holder_dll : intermod_holder_dll.cpp :
     <link>shared
     <define>BOOST_FLYWEIGHT_TEST_INTERMOD_HOLDER_DLL_SOURCE=1 ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,7 +9,7 @@
 
 project
     : requirements
-      <os>LINUX:<threading>multi
+      <target-os>linux:<threading>multi
     ;
 
 test-suite "flyweight" :


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.